### PR TITLE
Potential fix for code scanning alert no. 1: Storage of sensitive information in build artifact

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = [{
     },
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.UNSPLASH_API_KEY': JSON.stringify(process.env.UNSPLASH_API_KEY)
+            'process.env.UNSPLASH_API_KEY': 'undefined'
         }),
         new webpack.ProvidePlugin({
             process: 'process/browser'


### PR DESCRIPTION
Potential fix for [https://github.com/danielhaim1/autotoc/security/code-scanning/1](https://github.com/danielhaim1/autotoc/security/code-scanning/1)

The safest fix is to stop injecting `process.env.UNSPLASH_API_KEY` into the client bundle via `DefinePlugin`. For browser-targeted builds, secrets must never be bundled; instead, obtain credentials at runtime from a secure backend (or do not use secret credentials client-side at all). To avoid changing unrelated behavior, keep `DefinePlugin` but replace the secret value with a non-sensitive placeholder (`undefined`) so references still compile without embedding data.

In `webpack.config.js`, edit the first config object’s `plugins` section (around lines 53–55). Replace:

- `'process.env.UNSPLASH_API_KEY': JSON.stringify(process.env.UNSPLASH_API_KEY)`

with:

- `'process.env.UNSPLASH_API_KEY': 'undefined'`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
